### PR TITLE
adding redirects for 80

### DIFF
--- a/route/target.go
+++ b/route/target.go
@@ -85,4 +85,7 @@ func (t *Target) BuildRedirectURL(requestURL *url.URL) {
 	if t.RedirectURL.Path == "" {
 		t.RedirectURL.Path = "/"
 	}
+	if strings.Contains(t.RedirectURL.Host, "$host") {
+		t.RedirectURL.Host = strings.Replace(t.RedirectURL.Host, "$host", requestURL.Host, 1)
+	}
 }

--- a/route/target_test.go
+++ b/route/target_test.go
@@ -32,6 +32,16 @@ func TestTarget_BuildRedirectURL(t *testing.T) {
 				{req: "/?aaa=1", want: "http://bar.com/a/b/c?foo=bar"},
 			},
 		},
+		{ // simple http -> https redirect with static path
+			route: "route add redirect *:80/ https://$host/",
+			tests: []routeTest{
+				{req: "/", want: "https://foo.com/"},
+				{req: "/abc", want: "https://foo.com/"},
+				{req: "/a/b/c", want: "https://foo.com/"},
+				{req: "/?aaa=1", want: "https://foo.com/"},
+				{req: "/abc/?aaa=1", want: "https://foo.com/"},
+			},
+		},
 		{ // simple redirect to corresponding path
 			route: "route add svc / http://bar.com/$path",
 			tests: []routeTest{
@@ -42,7 +52,17 @@ func TestTarget_BuildRedirectURL(t *testing.T) {
 				{req: "/abc/?aaa=1", want: "http://bar.com/abc/?aaa=1"},
 			},
 		},
-		{ // same as above but without / before $path
+		{ // simple http -> https redirect to corresponding host & path
+			route: "route add redirect *:80/ https://$host/$path",
+			tests: []routeTest{
+				{req: "/", want: "https://foo.com/"},
+				{req: "/abc", want: "https://foo.com/abc"},
+				{req: "/a/b/c", want: "https://foo.com/a/b/c"},
+				{req: "/?aaa=1", want: "https://foo.com/?aaa=1"},
+				{req: "/abc/?aaa=1", want: "https://foo.com/abc/?aaa=1"},
+			},
+		},
+		{ // simple redirect to corresponding path without / before $path
 			route: "route add svc / http://bar.com$path",
 			tests: []routeTest{
 				{req: "/", want: "http://bar.com/"},
@@ -50,6 +70,16 @@ func TestTarget_BuildRedirectURL(t *testing.T) {
 				{req: "/a/b/c", want: "http://bar.com/a/b/c"},
 				{req: "/?aaa=1", want: "http://bar.com/?aaa=1"},
 				{req: "/abc/?aaa=1", want: "http://bar.com/abc/?aaa=1"},
+			},
+		},
+		{ // simple http -> https redirect to corresponding host & path without / before $path
+			route: "route add redirect *:80/ https://$host$path",
+			tests: []routeTest{
+				{req: "/", want: "https://foo.com/"},
+				{req: "/abc", want: "https://foo.com/abc"},
+				{req: "/a/b/c", want: "https://foo.com/a/b/c"},
+				{req: "/?aaa=1", want: "https://foo.com/?aaa=1"},
+				{req: "/abc/?aaa=1", want: "https://foo.com/abc/?aaa=1"},
 			},
 		},
 		{ // arbitrary subdir on target with $path at end
@@ -62,7 +92,17 @@ func TestTarget_BuildRedirectURL(t *testing.T) {
 				{req: "/abc/?aaa=1", want: "http://bar.com/bbb/abc/?aaa=1"},
 			},
 		},
-		{ // same as above but without / before $path
+		{ // http -> https redir to corresonding host w/ arbitrary subdir on target with $path at end
+			route: "route add redirect *:80/ https://$host/bbb/$path",
+			tests: []routeTest{
+				{req: "/", want: "https://foo.com/bbb/"},
+				{req: "/abc", want: "https://foo.com/bbb/abc"},
+				{req: "/a/b/c", want: "https://foo.com/bbb/a/b/c"},
+				{req: "/?aaa=1", want: "https://foo.com/bbb/?aaa=1"},
+				{req: "/abc/?aaa=1", want: "https://foo.com/bbb/abc/?aaa=1"},
+			},
+		},
+		{ // arbitrary subdir on target with $path at end but without / before $path
 			route: "route add svc / http://bar.com/bbb$path",
 			tests: []routeTest{
 				{req: "/", want: "http://bar.com/bbb/"},
@@ -70,6 +110,16 @@ func TestTarget_BuildRedirectURL(t *testing.T) {
 				{req: "/a/b/c", want: "http://bar.com/bbb/a/b/c"},
 				{req: "/?aaa=1", want: "http://bar.com/bbb/?aaa=1"},
 				{req: "/abc/?aaa=1", want: "http://bar.com/bbb/abc/?aaa=1"},
+			},
+		},
+		{ // http -> https redir to corresonding host w/ arbitrary subdir on target with $path at end but without / before $path
+			route: "route add redirect *:80/ https://$host/bbb$path",
+			tests: []routeTest{
+				{req: "/", want: "https://foo.com/bbb/"},
+				{req: "/abc", want: "https://foo.com/bbb/abc"},
+				{req: "/a/b/c", want: "https://foo.com/bbb/a/b/c"},
+				{req: "/?aaa=1", want: "https://foo.com/bbb/?aaa=1"},
+				{req: "/abc/?aaa=1", want: "https://foo.com/bbb/abc/?aaa=1"},
 			},
 		},
 		{ // strip prefix


### PR DESCRIPTION
Hi @jorgemarey I added some functionality to create global redirects from 80 to 443 also to force some endpoints to keep working on 80.

Here you have an example (with fabio with the next flag _**-proxy.addr "0.0.0.0:80;proto=http,0.0.0.0:443**_):

```
route add redirect *:80/ https://$host/$path opts "redirect=301"
route add consul consul.foo http://192.168.50.4:8500
route add nomad nomad.foo http://192.68.50.4:4646
route add fabio fabio.foo:80 http://192.168.50.4:1936
```

So when you want to connect to consul with http://consul.foo it'll redirect to https://consul.foo (the same with http://nomad-foo -> https://nomad.foo) whereas when http://fabio.foo it'll keep http://fabio.foo (https://fabio.foo won't work) 